### PR TITLE
Supported FreeBSD's loopback device.

### DIFF
--- a/loop.c
+++ b/loop.c
@@ -39,7 +39,11 @@ loop_tag(p, end)
 	memcpy(&af, p, sizeof af);
 	p += sizeof af;
 
+#if defined(__FreeBSD__)
+	switch (af) {
+#else
 	switch (ntohl(af)) {
+#endif
 	case AF_INET:
 		return ip_tag(p, end);
 #if HAVE_NETINET_IP6_H

--- a/main.c
+++ b/main.c
@@ -292,12 +292,15 @@ main(argc, argv)
 	case DLT_RAW:
 		fn = ip_tag;
 		break;
-#else
-# if defined(DLT_NULL)
+#endif
+#if defined(DLT_NULL)
 	case DLT_NULL:
+# if defined(__FreeBSD__)
+		fn = loop_tag;
+# else
 		fn = ip_tag;
-		break;
 # endif
+		break;
 #endif
 	default:
 		errx(1, "unknown datalink type %d", datalink_type);


### PR DESCRIPTION
Pktstat fails to use the loopback device on FreeBSD:

$ pktstat -i lo0 -w 1
pktstat: unknown datalink type 0

The attached patch fixes this failure.
Can you put it into your master branch?
