### PR TITLE
Replace printw(...) with printw("%s", ...)

### DIFF
--- a/display.c
+++ b/display.c
@@ -669,7 +669,7 @@ printhelp()
 			attron(A_REVERSE);
 		printw("%c", h->name[0]);
 		attroff(A_UNDERLINE);
-		printw((char *)h->name + 1);
+		printw("%s", (char *)h->name + 1);
 		attrset(0);
 		printw(" ");
 	}


### PR DESCRIPTION
Building with gcc 11.1.0 results in error:
```
display.c:672:17: error: format not a string literal and no format arguments [-Werror=format-security]
```
This patch fixes the issue by using "%s" as the format string instead.